### PR TITLE
fixed is_n_vector trait, now should build under all compilers

### DIFF
--- a/include/math/math_traits.h
+++ b/include/math/math_traits.h
@@ -95,12 +95,13 @@ constexpr bool is_integral_vector()
 	return false;
 }
 
-// Checks whether Vec is a floating-point vector type.
-template<typename V>
-constexpr bool is_n_vector(size_t component_count)
+// Checks whether Vec is N-dimensional vector known for math library.
+// Bool vectors are not supported because they still don't have vector traits.
+template<typename V, size_t N>
+constexpr bool is_n_vector()
 {
 	if constexpr (is_vector<V>::value)
-		return typename vector_traits<V>::component_count == component_count;
+		return vector_traits<V>::component_count == N;
 
 	return false;
 }

--- a/include/math/vector_utility.h
+++ b/include/math/vector_utility.h
@@ -88,7 +88,7 @@ inline float4 unpack_unorm_8_8_8_8(uint32_t val) noexcept
 // Returns component-wise minimum of two vectors.
 // Params:
 //        a, b = input values
-template <typename Vec2, std::enable_if_t<is_n_vector<Vec2>(2), int> = 0>
+template <typename Vec2, std::enable_if_t<is_n_vector<Vec2, 2>(), int> = 0>
 inline Vec2 min(const Vec2& a, const Vec2& b) noexcept
 {
     return Vec2(
@@ -100,7 +100,7 @@ inline Vec2 min(const Vec2& a, const Vec2& b) noexcept
 // Returns component-wise minimum of two vectors.
 // Params:
 //        a, b = input values
-template <typename Vec3, std::enable_if_t<is_n_vector<Vec3>(3), int> = 0>
+template <typename Vec3, std::enable_if_t<is_n_vector<Vec3, 3>(), int> = 0>
 inline Vec3 min(const Vec3& a, const Vec3& b) noexcept
 {
     return Vec3(
@@ -113,7 +113,7 @@ inline Vec3 min(const Vec3& a, const Vec3& b) noexcept
 // Returns component-wise minimum of two vectors.
 // Params:
 //        a, b = input values
-template <typename Vec4, std::enable_if_t<is_n_vector<Vec4>(4), int> = 0>
+template <typename Vec4, std::enable_if_t<is_n_vector<Vec4, 4>(), int> = 0>
 inline Vec4 min(const Vec4& a, const Vec4& b) noexcept
 {
     return Vec4(
@@ -127,7 +127,7 @@ inline Vec4 min(const Vec4& a, const Vec4& b) noexcept
 // Returns component-wise maximum if two vectors
 // Params:
 //        a, b = input values
-template <typename Vec2, std::enable_if_t<is_n_vector<Vec2>(2), int> = 0>
+template <typename Vec2, std::enable_if_t<is_n_vector<Vec2, 2>(), int> = 0>
 inline Vec2 max(const Vec2& a, const Vec2& b) noexcept
 {
     return Vec2(
@@ -139,7 +139,7 @@ inline Vec2 max(const Vec2& a, const Vec2& b) noexcept
 // Returns component-wise maximum if two vectors
 // Params:
 //        a, b = input values
-template <typename Vec3, std::enable_if_t<is_n_vector<Vec3>(3), int> = 0>
+template <typename Vec3, std::enable_if_t<is_n_vector<Vec3, 3>(), int> = 0>
 inline Vec3 max(const Vec3& a, const Vec3& b) noexcept
 {
     return Vec3(
@@ -152,7 +152,7 @@ inline Vec3 max(const Vec3& a, const Vec3& b) noexcept
 // Returns component-wise maximum if two vectors
 // Params:
 //        a, b = input values
-template <typename Vec4, std::enable_if_t<is_n_vector<Vec4>(4), int> = 0>
+template <typename Vec4, std::enable_if_t<is_n_vector<Vec4, 4>(), int> = 0>
 inline Vec4 max(const Vec4& a, const Vec4& b) noexcept
 {
     return Vec4(


### PR DESCRIPTION
previous version was unable to build under XCode (because of additional "typename" keyword at math_traits.h:103). Also component count argument of is_n_vector function moved to template arguments to avoid problems with same signature of min/max functions.